### PR TITLE
Fixed clear() only removing half the entities

### DIFF
--- a/source/geotic.js
+++ b/source/geotic.js
@@ -257,7 +257,7 @@ export const destroy = (e) => {
 }
 
 export const clear = () => {
-  entities.forEach(e => e.destroy());
+  entities.slice().forEach(e => e.destroy());
   sigs = new Map();
   tsigs = new Map();
   tags = new Map();


### PR DESCRIPTION
In `clear()`, when we call destroy on an entity it mutates the `entities` array we're iterating through, missing half of the entities (similar to [this example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#If_the_array_is_modified_during_iteration_other_elements_might_be_skipped.)). Shallow copying the `entities` array before iterating through it fixes the problem.