### PR TITLE
fixes #4 unable to serialise entities and tags

### DIFF
--- a/source/geotic.js
+++ b/source/geotic.js
@@ -89,7 +89,7 @@ class Entity {
   serialize() {
     return {
       id: this.id,
-      tags: Object.keys(this.t),
+      tags: Object.keys(this.tags),
       components: (() => {
         const s = [];
         for (let n of Object.keys(this.components)) {


### PR DESCRIPTION
There was an issue with serialising `tags`. This would cause any calls to `geotic.serialize()` or to `enity.serialize()` to fail. This was due to a misreferenced variable.