### PR TITLE
fix: preserve prototypes after merge in prefabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "geotic",
-    "version": "3.0.3",
+    "version": "3.0.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/PrefabComponent.js
+++ b/src/PrefabComponent.js
@@ -23,7 +23,7 @@ export default class PrefabComponent {
             }
         }
 
-        const props = merge(this.properties, initialProps);
+        const props = merge(this.properties, initialProps, { clone: false });
 
         entity.add(this.componentDef, props);
     }


### PR DESCRIPTION
Ran into an an issue with Prefabs where prototypes were striped during merge [here](https://github.com/ddmills/geotic/blob/c1deccc2396fcbe18bf07cc5fff79adfa6076c10/src/PrefabComponent.js#L26).

You can use the clone option in the deepmerge library to resolve the issue [per the docs](https://github.com/TehShrike/deepmerge#clone). The one catch being it's deprecated. Lodash merge also does the trick but breaks some of your tests and adds a new dependency so it would require a bit more effort.

Hopefully this PR is good enough or at least starts a conversation towards a resolution. 

Great effort so far! 

Cheers