### PR TITLE
Feat: Add by instance

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,13 +100,13 @@ Entity properties and methods:
 -   **ecs**: the geotic Engine instance
 -   **isDestroyed**: returns `true` if this entity is destroyed
 -   **components**: all component instances attached to this entity
--   **add(componentName, props={})**: create and add registered component to the entity
+-   **add(componentName, props={})**: create and add registered component to the entity. A component instance can also be supplied.
 -   **has(componentName, key='')**: returns true if entity has component
 -   **get(componentName, key='')**: get a component attached to this entity
 -   **owns(component)**: returns `true` if the specified component belongs to this entity
 -   **destroy()**: destroy the entity and all of it's components
 -   **remove(componentName, key='')**: remove (detach) component from the entity
--   **attach(component)**: attach a component that has been removed
+-   *DEPRECIATED* **attach(component)**: attach a component that has been removed. *DEPRECIATED*: Use `.add(instance)` instead!
 -   **serialize()**: serialize this entity and it's components
 -   **fireEvent(name, data={})**: send an event to all components on the entity
 
@@ -265,7 +265,7 @@ playerA.add(someComponent);
 
 const clonedComponent = playerA.someComponent.clone();
 
-playerB.attach(clonedComponent); // note the use of `attach` here
+playerB.add(clonedComponent);
 ```
 
 ### queries

--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ Entity properties and methods:
 -   **owns(component)**: returns `true` if the specified component belongs to this entity
 -   **destroy()**: destroy the entity and all of it's components
 -   **remove(componentName, key='')**: remove (detach) component from the entity
--   *DEPRECIATED* **attach(component)**: attach a component that has been removed. *DEPRECIATED*: Use `.add(instance)` instead!
+-   _DEPRECIATED_ **attach(component)**: attach a component that has been removed. _DEPRECIATED_: Use `.add(instance)` instead!
 -   **serialize()**: serialize this entity and it's components
 -   **fireEvent(name, data={})**: send an event to all components on the entity
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -117,10 +117,7 @@ export default class Component {
     }
 
     clone() {
-        return this.ecs.createComponent(
-            this.type,
-            this.serialize()
-        );
+        return this.ecs.createComponent(this.type, this.serialize());
     }
 
     _onEvent(evt) {

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -70,6 +70,17 @@ export default class Entity {
     }
 
     add(typeOrClass, properties = {}) {
+        if (typeOrClass instanceof Component) {
+            if (typeOrClass.isAttached) {
+                console.warn(
+                    `"${typeOrClass.type}" component cannot be added, since it is already attached to an entity.`
+                );
+                return false;
+            }
+
+            return this.attach(typeOrClass);
+        }
+
         const component = this.ecs.components.create(typeOrClass, properties);
 
         if (!component) {

--- a/src/Prefab.js
+++ b/src/Prefab.js
@@ -29,12 +29,8 @@ export default class Prefab {
                 if (definition.keyProperty) {
                     const key = component.properties[definition.keyProperty];
 
-                    if (
-                        initialProps[accessor] &&
-                        initialProps[accessor][key]
-                    ) {
-                        initialCompProps =
-                            initialProps[accessor][key];
+                    if (initialProps[accessor] && initialProps[accessor][key]) {
+                        initialCompProps = initialProps[accessor][key];
                     }
                 } else {
                     if (!arrComps[accessor]) {
@@ -43,14 +39,10 @@ export default class Prefab {
 
                     if (
                         initialProps[accessor] &&
-                        initialProps[accessor][
-                            arrComps[accessor]
-                        ]
+                        initialProps[accessor][arrComps[accessor]]
                     ) {
                         initialCompProps =
-                            initialProps[accessor][
-                                arrComps[accessor]
-                            ];
+                            initialProps[accessor][arrComps[accessor]];
                     }
 
                     arrComps[accessor]++;

--- a/tests/unit/Entity.spec.js
+++ b/tests/unit/Entity.spec.js
@@ -107,6 +107,150 @@ describe('Entity', () => {
         });
     });
 
+    describe('add', () => {
+        let entity;
+
+        beforeEach(() => {
+            entity = engine.createEntity();
+        });
+
+        describe('simple components', () => {
+            describe.each([
+                ['class', () => (
+                    entity.add(TestComponent)
+                )],
+                ['type', () => (
+                    entity.add('TestComponent')
+                )],
+            ])('when added by %s', (def, fn) => {
+                let result;
+
+                beforeEach(() => {
+                    result = fn();
+                });
+
+                it('should add the component to the entity as a camel cased property', () => {
+                    expect(entity.testComponent).toBeDefined();
+                });
+
+                it('should include the component in the entity list', () => {
+                    expect(entity.components.testComponent).toBeTruthy();
+                });
+
+                it('should have the correct type of components', () => {
+                    expect(entity.testComponent).toBeInstanceOf(TestComponent);
+                });
+
+                it('should return TRUE', () => {
+                    expect(result).toBe(true);
+                });
+            });
+        });
+
+        describe('keyed components', () => {
+            let nameA, nameB;
+
+            beforeEach(() => {
+                nameA = chance.word();
+                nameB = chance.word();
+            });
+
+            describe.each([
+                ['class', () => [
+                    entity.add(NestedComponent, { name: nameA }),
+                    entity.add(NestedComponent, { name: nameB }),
+                ]],
+                ['type', () => [
+                    entity.add('NestedComponent', { name: nameA }),
+                    entity.add('NestedComponent', { name: nameB }),
+                ]],
+            ])('when added by %s', (def, fn) => {
+                let result;
+
+                beforeEach(() => {
+                    result = fn();
+                });
+
+                it('should add the components to the entity as a camel cased property', () => {
+                    expect(entity.nestedComponent[nameA]).toBeDefined();
+                    expect(entity.nestedComponent[nameB]).toBeDefined();
+                });
+
+                it('should have the correct type of components', () => {
+                    expect(entity.nestedComponent[nameA]).toBeInstanceOf(NestedComponent);
+                    expect(entity.nestedComponent[nameB]).toBeInstanceOf(NestedComponent);
+                });
+
+                it('should set component properties', () => {
+                    expect(entity.nestedComponent[nameA].name).toBe(nameA);
+                    expect(entity.nestedComponent[nameB].name).toBe(nameB);
+                });
+
+                it('should return TRUE', () => {
+                    expect(result[0]).toBe(true);
+                    expect(result[1]).toBe(true);
+                });
+            });
+        });
+
+        describe('array components', () => {
+            let nameA, nameB;
+
+            beforeEach(() => {
+                nameA = chance.word();
+                nameB = chance.word();
+            });
+
+            describe.each([
+                ['class', () => [
+                    entity.add(ArrayComponent, { name: nameA }),
+                    entity.add(ArrayComponent, { name: nameB }),
+                ]],
+                ['type', () => [
+                    entity.add('ArrayComponent', { name: nameA }),
+                    entity.add('ArrayComponent', { name: nameB }),
+                ]],
+            ])('when added by %s', (def, fn) => {
+                let result;
+
+                beforeEach(() => {
+                    result = fn();
+                });
+
+                it('should add the components to the entity as a camel cased array property', () => {
+                    expect(entity.arrayComponent).toBeDefined();
+                    expect(entity.arrayComponent).toHaveLength(2);
+                    expect(entity.arrayComponent[0].name).toBe(nameA);
+                    expect(entity.arrayComponent[1].name).toBe(nameB);
+                });
+
+                it('should mark the components as "attached"', () => {
+                    expect(entity.arrayComponent[0].isAttached).toBe(true);
+                    expect(entity.arrayComponent[1].isAttached).toBe(true);
+                });
+
+                it('should include the components in the entity list', () => {
+                    expect(entity.components.arrayComponent).toHaveLength(2);
+                });
+
+                it('should have the correct type of components', () => {
+                    expect(entity.arrayComponent[0]).toBeInstanceOf(ArrayComponent);
+                    expect(entity.arrayComponent[1]).toBeInstanceOf(ArrayComponent);
+                });
+
+                it('should set component properties', () => {
+                    expect(entity.arrayComponent[0].name).toBe(nameA);
+                    expect(entity.arrayComponent[1].name).toBe(nameB);
+                });
+
+                it('should return TRUE', () => {
+                    expect(result[0]).toBe(true);
+                    expect(result[1]).toBe(true);
+                });
+            });
+        });
+    });
+
     describe('remove', () => {
         let entity;
 

--- a/tests/unit/Entity.spec.js
+++ b/tests/unit/Entity.spec.js
@@ -116,15 +116,9 @@ describe('Entity', () => {
 
         describe('simple components', () => {
             describe.each([
-                ['class', () => (
-                    entity.add(TestComponent)
-                )],
-                ['type', () => (
-                    entity.add('TestComponent')
-                )],
-                ['instance', () => (
-                    entity.add(new TestComponent(engine))
-                )],
+                ['class', () => entity.add(TestComponent)],
+                ['type', () => entity.add('TestComponent')],
+                ['instance', () => entity.add(new TestComponent(engine))],
             ])('when added by %s', (def, fn) => {
                 let result;
 
@@ -196,18 +190,31 @@ describe('Entity', () => {
             });
 
             describe.each([
-                ['class', () => [
-                    entity.add(NestedComponent, { name: nameA }),
-                    entity.add(NestedComponent, { name: nameB }),
-                ]],
-                ['type', () => [
-                    entity.add('NestedComponent', { name: nameA }),
-                    entity.add('NestedComponent', { name: nameB }),
-                ]],
-                ['instance', () => [
-                    entity.add(new NestedComponent(engine, { name: nameA })),
-                    entity.add(new NestedComponent(engine, { name: nameB })),
-                ]],
+                [
+                    'class',
+                    () => [
+                        entity.add(NestedComponent, { name: nameA }),
+                        entity.add(NestedComponent, { name: nameB }),
+                    ],
+                ],
+                [
+                    'type',
+                    () => [
+                        entity.add('NestedComponent', { name: nameA }),
+                        entity.add('NestedComponent', { name: nameB }),
+                    ],
+                ],
+                [
+                    'instance',
+                    () => [
+                        entity.add(
+                            new NestedComponent(engine, { name: nameA })
+                        ),
+                        entity.add(
+                            new NestedComponent(engine, { name: nameB })
+                        ),
+                    ],
+                ],
             ])('when added by %s', (def, fn) => {
                 let result;
 
@@ -221,8 +228,12 @@ describe('Entity', () => {
                 });
 
                 it('should have the correct type of components', () => {
-                    expect(entity.nestedComponent[nameA]).toBeInstanceOf(NestedComponent);
-                    expect(entity.nestedComponent[nameB]).toBeInstanceOf(NestedComponent);
+                    expect(entity.nestedComponent[nameA]).toBeInstanceOf(
+                        NestedComponent
+                    );
+                    expect(entity.nestedComponent[nameB]).toBeInstanceOf(
+                        NestedComponent
+                    );
                 });
 
                 it('should set component properties', () => {
@@ -263,15 +274,14 @@ describe('Entity', () => {
                         engine.createEntity().add(instanceA);
                         engine.createEntity().add(instanceB);
 
-                        result = [
-                            entity.add(instanceA),
-                            entity.add(instanceB),
-                        ];
+                        result = [entity.add(instanceA), entity.add(instanceB)];
                     });
 
                     it('should not attach the instances', () => {
                         expect(entity.has(NestedComponent)).toBe(false);
-                        expect(entity.components.nestedComponent).toBeUndefined();
+                        expect(
+                            entity.components.nestedComponent
+                        ).toBeUndefined();
                     });
 
                     it('should return false', () => {
@@ -290,18 +300,27 @@ describe('Entity', () => {
             });
 
             describe.each([
-                ['class', () => [
-                    entity.add(ArrayComponent, { name: nameA }),
-                    entity.add(ArrayComponent, { name: nameB }),
-                ]],
-                ['type', () => [
-                    entity.add('ArrayComponent', { name: nameA }),
-                    entity.add('ArrayComponent', { name: nameB }),
-                ]],
-                ['instance', () => [
-                    entity.add(new ArrayComponent(engine, { name: nameA })),
-                    entity.add(new ArrayComponent(engine, { name: nameB })),
-                ]],
+                [
+                    'class',
+                    () => [
+                        entity.add(ArrayComponent, { name: nameA }),
+                        entity.add(ArrayComponent, { name: nameB }),
+                    ],
+                ],
+                [
+                    'type',
+                    () => [
+                        entity.add('ArrayComponent', { name: nameA }),
+                        entity.add('ArrayComponent', { name: nameB }),
+                    ],
+                ],
+                [
+                    'instance',
+                    () => [
+                        entity.add(new ArrayComponent(engine, { name: nameA })),
+                        entity.add(new ArrayComponent(engine, { name: nameB })),
+                    ],
+                ],
             ])('when added by %s', (def, fn) => {
                 let result;
 
@@ -326,8 +345,12 @@ describe('Entity', () => {
                 });
 
                 it('should have the correct type of components', () => {
-                    expect(entity.arrayComponent[0]).toBeInstanceOf(ArrayComponent);
-                    expect(entity.arrayComponent[1]).toBeInstanceOf(ArrayComponent);
+                    expect(entity.arrayComponent[0]).toBeInstanceOf(
+                        ArrayComponent
+                    );
+                    expect(entity.arrayComponent[1]).toBeInstanceOf(
+                        ArrayComponent
+                    );
                 });
 
                 it('should set component properties', () => {
@@ -368,15 +391,14 @@ describe('Entity', () => {
                         engine.createEntity().add(instanceA);
                         engine.createEntity().add(instanceB);
 
-                        result = [
-                            entity.add(instanceA),
-                            entity.add(instanceB),
-                        ];
+                        result = [entity.add(instanceA), entity.add(instanceB)];
                     });
 
                     it('should not attach the instances', () => {
                         expect(entity.has(ArrayComponent)).toBe(false);
-                        expect(entity.components.arrayComponent).toBeUndefined();
+                        expect(
+                            entity.components.arrayComponent
+                        ).toBeUndefined();
                     });
 
                     it('should return false', () => {

--- a/tests/unit/Entity.spec.js
+++ b/tests/unit/Entity.spec.js
@@ -122,6 +122,9 @@ describe('Entity', () => {
                 ['type', () => (
                     entity.add('TestComponent')
                 )],
+                ['instance', () => (
+                    entity.add(new TestComponent(engine))
+                )],
             ])('when added by %s', (def, fn) => {
                 let result;
 
@@ -145,6 +148,43 @@ describe('Entity', () => {
                     expect(result).toBe(true);
                 });
             });
+
+            describe('when instance is added', () => {
+                let instance;
+
+                beforeEach(() => {
+                    instance = new TestComponent(engine);
+                });
+
+                describe('when instance is not attached to an entity', () => {
+                    beforeEach(() => {
+                        entity.add(instance);
+                    });
+
+                    it('should attach the same exact instance', () => {
+                        expect(entity.testComponent).toBe(instance);
+                    });
+                });
+
+                describe('when instance is already attached to an entity', () => {
+                    let result;
+
+                    beforeEach(() => {
+                        engine.createEntity().add(instance);
+
+                        result = entity.add(instance);
+                    });
+
+                    it('should not attach the instance', () => {
+                        expect(entity.has(TestComponent)).toBe(false);
+                        expect(entity.components.testComponent).toBeUndefined();
+                    });
+
+                    it('should return false', () => {
+                        expect(result).toBe(false);
+                    });
+                });
+            });
         });
 
         describe('keyed components', () => {
@@ -163,6 +203,10 @@ describe('Entity', () => {
                 ['type', () => [
                     entity.add('NestedComponent', { name: nameA }),
                     entity.add('NestedComponent', { name: nameB }),
+                ]],
+                ['instance', () => [
+                    entity.add(new NestedComponent(engine, { name: nameA })),
+                    entity.add(new NestedComponent(engine, { name: nameB })),
                 ]],
             ])('when added by %s', (def, fn) => {
                 let result;
@@ -191,6 +235,50 @@ describe('Entity', () => {
                     expect(result[1]).toBe(true);
                 });
             });
+
+            describe('when instances are added', () => {
+                let instanceA, instanceB;
+
+                beforeEach(() => {
+                    instanceA = new NestedComponent(engine, { name: nameA });
+                    instanceB = new NestedComponent(engine, { name: nameB });
+                });
+
+                describe('when instances are not attached to an entity', () => {
+                    beforeEach(() => {
+                        entity.add(instanceA);
+                        entity.add(instanceB);
+                    });
+
+                    it('should attach the same exact instances', () => {
+                        expect(entity.nestedComponent[nameA]).toBe(instanceA);
+                        expect(entity.nestedComponent[nameB]).toBe(instanceB);
+                    });
+                });
+
+                describe('when instances are already attached to an entity', () => {
+                    let result;
+
+                    beforeEach(() => {
+                        engine.createEntity().add(instanceA);
+                        engine.createEntity().add(instanceB);
+
+                        result = [
+                            entity.add(instanceA),
+                            entity.add(instanceB),
+                        ];
+                    });
+
+                    it('should not attach the instances', () => {
+                        expect(entity.has(NestedComponent)).toBe(false);
+                        expect(entity.components.nestedComponent).toBeUndefined();
+                    });
+
+                    it('should return false', () => {
+                        expect(result).toStrictEqual([false, false]);
+                    });
+                });
+            });
         });
 
         describe('array components', () => {
@@ -209,6 +297,10 @@ describe('Entity', () => {
                 ['type', () => [
                     entity.add('ArrayComponent', { name: nameA }),
                     entity.add('ArrayComponent', { name: nameB }),
+                ]],
+                ['instance', () => [
+                    entity.add(new ArrayComponent(engine, { name: nameA })),
+                    entity.add(new ArrayComponent(engine, { name: nameB })),
                 ]],
             ])('when added by %s', (def, fn) => {
                 let result;
@@ -246,6 +338,50 @@ describe('Entity', () => {
                 it('should return TRUE', () => {
                     expect(result[0]).toBe(true);
                     expect(result[1]).toBe(true);
+                });
+            });
+
+            describe('when instances are added', () => {
+                let instanceA, instanceB;
+
+                beforeEach(() => {
+                    instanceA = new ArrayComponent(engine, { name: nameA });
+                    instanceB = new ArrayComponent(engine, { name: nameB });
+                });
+
+                describe('when instances are not attached to an entity', () => {
+                    beforeEach(() => {
+                        entity.add(instanceA);
+                        entity.add(instanceB);
+                    });
+
+                    it('should attach the same exact instances', () => {
+                        expect(entity.arrayComponent[0]).toBe(instanceA);
+                        expect(entity.arrayComponent[1]).toBe(instanceB);
+                    });
+                });
+
+                describe('when instances are already attached to an entity', () => {
+                    let result;
+
+                    beforeEach(() => {
+                        engine.createEntity().add(instanceA);
+                        engine.createEntity().add(instanceB);
+
+                        result = [
+                            entity.add(instanceA),
+                            entity.add(instanceB),
+                        ];
+                    });
+
+                    it('should not attach the instances', () => {
+                        expect(entity.has(ArrayComponent)).toBe(false);
+                        expect(entity.components.arrayComponent).toBeUndefined();
+                    });
+
+                    it('should return false', () => {
+                        expect(result).toStrictEqual([false, false]);
+                    });
                 });
             });
         });


### PR DESCRIPTION
Allow components to be added to an entity by `instance`, also adds a ton of tests for `entity.add`