### PR TITLE
Cache expensive camelcase results for performance improvement

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -1,4 +1,4 @@
-import camelcase from 'camelcase';
+import { camelString } from './util/string-util';
 import PropertyFactory from './Properties/PropertyFactory';
 
 export default class Component {
@@ -123,7 +123,7 @@ export default class Component {
     _onEvent(evt) {
         this.onEvent(evt);
 
-        const handlerName = camelcase(`on ${evt.name}`);
+        const handlerName = camelString(`on ${evt.name}`);
 
         if (typeof this[handlerName] === 'function') {
             this[handlerName](evt);

--- a/src/Registries/ComponentRegistry.js
+++ b/src/Registries/ComponentRegistry.js
@@ -1,8 +1,7 @@
 import Component from '../Component';
-import camelcase from 'camelcase';
+import { camelString } from '../util/string-util';
 
 export default class ComponentRegistry {
-    #nameCache = new Map();
     #definitions = new Map();
     #ecs = null;
 
@@ -12,15 +11,11 @@ export default class ComponentRegistry {
 
     register(component) {
         this.#definitions.set(component.name, component);
-        this.#nameCache.set(component.name, camelcase(component.name));
+        camelString(component.name); // prime camelcase cache
     }
 
     getAccessor(type) {
-        if (this.#nameCache.has(type)) {
-            return this.#nameCache.get(type);
-        }
-
-        this.#nameCache.set(type, camelcase(type));
+        return camelString(type);
     }
 
     get(typeOrClassOrComponent) {

--- a/src/Registries/EntityRegistry.js
+++ b/src/Registries/EntityRegistry.js
@@ -1,5 +1,5 @@
+import { pascalString } from '../util/string-util';
 import Entity from '../Entity';
-import camelcase from 'camelcase';
 
 export default class EntityRegistry {
     #entities = new Map();
@@ -109,7 +109,7 @@ export default class EntityRegistry {
         const entity = this.createOrGetById(id);
 
         Object.entries(componentData).forEach(([key, value]) => {
-            const type = camelcase(key, { pascalCase: true });
+            const type = pascalString(key);
             const definition = this.#ecs.components.get(type);
 
             if (definition.allowMultiple) {

--- a/src/util/string-util.js
+++ b/src/util/string-util.js
@@ -1,0 +1,21 @@
+import camelcaseSlow from 'camelcase';
+
+const camelCache = new Map();
+
+export const camelString = (value) => {
+    if (!camelCache.has(value)) {
+        camelCache.set(value, camelcaseSlow(value));
+    }
+
+    return camelCache.get(value);
+};
+
+const pascalCache = new Map();
+
+export const pascalString = (value) => {
+    if (!pascalCache.has(value)) {
+        pascalCache.set(value, camelcaseSlow(value, { pascalCase: true }));
+    }
+
+    return pascalCache.get(value);
+};


### PR DESCRIPTION
`camelcase` is stupid expensive for some reason, this just memoizes the results